### PR TITLE
Fix error with agent requests header to X-GitHub-Public-Key-Signature

### DIFF
--- a/agent/service.go
+++ b/agent/service.go
@@ -39,7 +39,7 @@ func NewService(pubKey *ecdsa.PublicKey) *Service {
 }
 
 func (s *Service) ChatCompletion(w http.ResponseWriter, r *http.Request) {
-	sig := r.Header.Get("Github-Public-Key-Signature")
+	sig := r.Header.Get("X-GitHub-Public-Key-Signature")
 
 	body, err := io.ReadAll(r.Body)
 	if err != nil {


### PR DESCRIPTION
The current application fails to start with `go run .` with a following error: `failed to validate payload signature: asn1: syntax error: sequence truncated.` 

After some debugging, the error happens to due to `sig` value in the line `sig := r.Header.Get("GitHub-Public-Key-Signature")` of `service.go` file's `ChatCompletion` function returning nothing. 

This happened because the header changed from `GitHub-Public-Key-Signature` to `X-GitHub-Public-Key-Signature` as seen here:  

https://docs.github.com/en/copilot/building-copilot-extensions/building-a-copilot-agent-for-your-copilot-extension/configuring-your-copilot-agent-to-communicate-with-github#verifying-that-payloads-are-coming-from-github